### PR TITLE
Updated against latest gql API (Server 0.12.1)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,3 +1,3 @@
-AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:4433/
+AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/identity/ory/kratos/public
 AUTH_ADMIN_EMAIL=admin@alkem.io
 AUTH_ADMIN_PASSWORD=changeMe

--- a/.graphqlrc.json
+++ b/.graphqlrc.json
@@ -1,4 +1,4 @@
 {
-  "schema": "http://localhost:4000/graphql",
+  "schema": "http://localhost:3000/graphql",
   "documents:": "graphql/**/*.graphql"
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Finally, this package provides a utility for carrying out performance test data 
 To use this package, first instantiate an instance of the AlkemioClient class, passing in the Alkemio server end point:
 ```
   const ctClient = new AlkemioClient({
-    graphqlEndpoint: 'http://localhost:4000/graphql',
+    graphqlEndpoint: 'http://localhost:3000/graphql',
   });
   ```
 The ctClient can then be used to access the Alkemio server api using provided wrapper methods e.g.
@@ -34,7 +34,7 @@ The set of wrapper calls provided is based on needs to date; feel free to augmen
 The default usage for client-lib is against an non-authenticated server, but it can also be run against a server with authentication enabled.
 
 There is a sample program provided, `npm run get-api-token`, that reads in the following environment variables to authenticate:
-* AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:4433/
+* AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
 * AUTH_ADMIN_EMAIL=admin@alkem.io
 * AUTH_ADMIN_PASSWORD=changeMe
 To set these, make a copy of the provided `.env.default` as `.env` and edit to reflect the target server values.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The set of wrapper calls provided is based on needs to date; feel free to augmen
 The default usage for client-lib is against an non-authenticated server, but it can also be run against a server with authentication enabled.
 
 There is a sample program provided, `npm run get-api-token`, that reads in the following environment variables to authenticate:
-* AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/ory/kratos/public
+* AUTH_ORY_KRATOS_PUBLIC_BASE_URL=http://localhost:3000/identity/ory/kratos/public
 * AUTH_ADMIN_EMAIL=admin@alkem.io
 * AUTH_ADMIN_PASSWORD=changeMe
 To set these, make a copy of the provided `.env.default` as `.env` and edit to reflect the target server values.

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,6 +1,6 @@
 overwrite: true
-schema: "http://localhost:4000/graphql"
-documents: "graphql/**/*.graphql"
+schema: 'http://localhost:3000/graphql'
+documents: 'graphql/**/*.graphql'
 hooks:
   afterAllFileWrite:
     - eslint --fix
@@ -28,7 +28,7 @@ generates:
       importTypesNamespace: SchemaTypes
     plugins:
       - add:
-          content: "/* eslint-disable @typescript-eslint/no-explicit-any */"
+          content: '/* eslint-disable @typescript-eslint/no-explicit-any */'
       - typescript-operations
       - typescript-graphql-request
     config:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-lib",
-  "version": "0.7.12",
+  "version": "0.7.14",
   "description": "Library for interacting with a Alkemio server instance",
   "author": "Cherrytwist Foundation",
   "private": false,
@@ -62,6 +62,7 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">=14.17.3"
+    "node": ">=14.17.3",
+    "npm": ">=7"
   }
 }

--- a/src/AlkemioClient.ts
+++ b/src/AlkemioClient.ts
@@ -64,7 +64,7 @@ export class AlkemioClient {
       configuration.data?.configuration.authentication.providers[0].config
         .kratosPublicBaseURL;
 
-    return endpoint ?? 'http://localhost:4433/';
+    return endpoint ?? 'http://localhost:3000/ory/kratos/public/';
   }
 
   public async isAuthenticationEnabled(): Promise<boolean> {
@@ -101,12 +101,14 @@ export class AlkemioClient {
       );
     }
     const serverMetaData = data?.metadata.services.find(
-      service => service.name === 'ct-server'
+      service => service.name === 'alkemio-server'
     );
     if (!serverMetaData) throw new Error('Unable to locate server meta data');
     const serverVersion = serverMetaData.version;
     if (!serverVersion)
-      throw new Error(`Unable to retrive CT server version: ${serverVersion}`);
+      throw new Error(
+        `Unable to retrive Alkemio server version: ${serverVersion}`
+      );
     return serverVersion;
   }
 

--- a/src/AlkemioClient.ts
+++ b/src/AlkemioClient.ts
@@ -64,7 +64,7 @@ export class AlkemioClient {
       configuration.data?.configuration.authentication.providers[0].config
         .kratosPublicBaseURL;
 
-    return endpoint ?? 'http://localhost:3000/ory/kratos/public/';
+    return endpoint ?? 'http://localhost:3000/identity/ory/kratos/public/';
   }
 
   public async isAuthenticationEnabled(): Promise<boolean> {

--- a/src/performance/performance-test-data-population.ts
+++ b/src/performance/performance-test-data-population.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 
 const baseUrlDev = 'https://dev.alkem.io/graphql';
 const baseUrlTest = 'https://test.alkem.io/graphql';
-const baseUrlLocalhost = 'http://localhost:4000/graphql';
+const baseUrlLocalhost = 'http://localhost:3000/graphql';
 
 //,
 const authorizationToken = 'Bearer {token}';

--- a/src/types/alkemio-schema.ts
+++ b/src/types/alkemio-schema.ts
@@ -115,8 +115,28 @@ export type Aspect = {
   title: Scalars['String'];
 };
 
+export type AssignChallengeAdminInput = {
+  challengeID: Scalars['UUID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
 export type AssignCommunityMemberInput = {
   communityID: Scalars['UUID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type AssignEcoverseAdminInput = {
+  ecoverseID: Scalars['UUID_NAMEID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type AssignOrganisationAdminInput = {
+  organisationID: Scalars['UUID_NAMEID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type AssignOrganisationMemberInput = {
+  organisationID: Scalars['UUID_NAMEID'];
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
@@ -149,11 +169,11 @@ export type AuthenticationProviderConfigUnion = OryConfig;
 
 export type Authorization = {
   anonymousReadAccess: Scalars['Boolean'];
-  /** The set of credential rules that are contained by this AuthorizationDefinition. */
+  /** The set of credential rules that are contained by this Authorization Policy. */
   credentialRules?: Maybe<Array<AuthorizationRuleCredential>>;
   /** The ID of the entity */
   id: Scalars['UUID'];
-  /** The set of verified credential rules that are contained by this AuthorizationDefinition. */
+  /** The set of verified credential rules that are contained by this Authorization Policy. */
   verifiedCredentialRules?: Maybe<Array<AuthorizationRuleCredential>>;
 };
 
@@ -355,7 +375,7 @@ export type CreateChallengeInput = {
 };
 
 export type CreateContextInput = {
-  background?: Maybe<Scalars['String']>;
+  background?: Maybe<Scalars['Markdown']>;
   impact?: Maybe<Scalars['Markdown']>;
   /** Set of References for the new Context. */
   references?: Maybe<Array<CreateReferenceInput>>;
@@ -363,7 +383,7 @@ export type CreateContextInput = {
   vision?: Maybe<Scalars['Markdown']>;
   /** The Visual assets for the new Context. */
   visual?: Maybe<CreateVisualInput>;
-  who?: Maybe<Scalars['String']>;
+  who?: Maybe<Scalars['Markdown']>;
 };
 
 export type CreateEcoverseInput = {
@@ -634,7 +654,7 @@ export type EcoverseProjectArgs = {
 };
 
 export type EcoverseAuthorizationResetInput = {
-  /** The identifier of the Ecoverse whose AuthorizationDefinition should be reset. */
+  /** The identifier of the Ecoverse whose Authorization Policy should be reset. */
   ecoverseID: Scalars['UUID_NAMEID'];
 };
 
@@ -739,10 +759,18 @@ export type Metadata = {
 };
 
 export type Mutation = {
+  /** Assigns a User as an Challenge Admin. */
+  assignUserAsChallengeAdmin: User;
+  /** Assigns a User as an Ecoverse Admin. */
+  assignUserAsEcoverseAdmin: User;
+  /** Assigns a User as an Organisation Admin. */
+  assignUserAsOrganisationAdmin: User;
   /** Assigns a User as a member of the specified Community. */
   assignUserToCommunity: Community;
   /** Assigns a User as a member of the specified User Group. */
   assignUserToGroup: UserGroup;
+  /** Assigns a User as a member of the specified Organisation. */
+  assignUserToOrganisation: Organisation;
   /** Reset the Authorization Policy on the specified Ecoverse. */
   authorizationPolicyResetOnEcoverse: Ecoverse;
   /** Reset the Authorization Policy on the specified Organisation. */
@@ -829,10 +857,16 @@ export type Mutation = {
   messageUpdateCommunity: Scalars['String'];
   /** Sends a message on the specified User`s behalf and returns the room id */
   messageUser: Scalars['String'];
+  /** Removes a User from being an Ecoverse Admin. */
+  removeUserAsChallengeAdmin: User;
+  /** Removes a User from being an Organisation Admin. */
+  removeUserAsOrganisationAdmin: User;
   /** Removes a User as a member of the specified Community. */
   removeUserFromCommunity: Community;
   /** Removes the specified User from specified user group */
   removeUserFromGroup: UserGroup;
+  /** Removes a User as a member of the specified Organisation. */
+  removeUserFromOrganisation: Organisation;
   /** Removes an authorization credential from a User. */
   revokeCredentialFromUser: User;
   /** Updates the specified Actor. */
@@ -859,12 +893,28 @@ export type Mutation = {
   uploadAvatar: Profile;
 };
 
+export type MutationAssignUserAsChallengeAdminArgs = {
+  membershipData: AssignChallengeAdminInput;
+};
+
+export type MutationAssignUserAsEcoverseAdminArgs = {
+  membershipData: AssignEcoverseAdminInput;
+};
+
+export type MutationAssignUserAsOrganisationAdminArgs = {
+  membershipData: AssignOrganisationAdminInput;
+};
+
 export type MutationAssignUserToCommunityArgs = {
   membershipData: AssignCommunityMemberInput;
 };
 
 export type MutationAssignUserToGroupArgs = {
   membershipData: AssignUserGroupMemberInput;
+};
+
+export type MutationAssignUserToOrganisationArgs = {
+  membershipData: AssignOrganisationMemberInput;
 };
 
 export type MutationAuthorizationPolicyResetOnEcoverseArgs = {
@@ -1035,12 +1085,24 @@ export type MutationMessageUserArgs = {
   msgData: UserSendMessageInput;
 };
 
+export type MutationRemoveUserAsChallengeAdminArgs = {
+  membershipData: RemoveEcoverseAdminInput;
+};
+
+export type MutationRemoveUserAsOrganisationAdminArgs = {
+  membershipData: RemoveOrganisationAdminInput;
+};
+
 export type MutationRemoveUserFromCommunityArgs = {
   membershipData: RemoveCommunityMemberInput;
 };
 
 export type MutationRemoveUserFromGroupArgs = {
   membershipData: RemoveUserGroupMemberInput;
+};
+
+export type MutationRemoveUserFromOrganisationArgs = {
+  membershipData: RemoveOrganisationMemberInput;
 };
 
 export type MutationRevokeCredentialFromUserArgs = {
@@ -1168,7 +1230,7 @@ export type OrganisationGroupArgs = {
 };
 
 export type OrganisationAuthorizationResetInput = {
-  /** The identifier of the Organisation whose AuthorizationDefinition should be reset. */
+  /** The identifier of the Organisation whose Authorization Policy should be reset. */
   organisationID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
@@ -1354,6 +1416,21 @@ export type RemoveCommunityMemberInput = {
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 
+export type RemoveEcoverseAdminInput = {
+  ecoverseID: Scalars['UUID_NAMEID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RemoveOrganisationAdminInput = {
+  organisationID: Scalars['UUID_NAMEID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
+export type RemoveOrganisationMemberInput = {
+  organisationID: Scalars['UUID_NAMEID'];
+  userID: Scalars['UUID_NAMEID_EMAIL'];
+};
+
 export type RemoveUserGroupMemberInput = {
   groupID: Scalars['UUID'];
   userID: Scalars['UUID_NAMEID_EMAIL'];
@@ -1449,7 +1526,7 @@ export type UpdateAspectInput = {
   title?: Maybe<Scalars['String']>;
 };
 
-export type UpdateAuthorizationDefinitionInput = {
+export type UpdateAuthorizationPolicyInput = {
   anonymousReadAccess: Scalars['Boolean'];
 };
 
@@ -1468,7 +1545,7 @@ export type UpdateChallengeInput = {
 };
 
 export type UpdateContextInput = {
-  background?: Maybe<Scalars['String']>;
+  background?: Maybe<Scalars['Markdown']>;
   impact?: Maybe<Scalars['Markdown']>;
   /** Update the set of References for the Context. */
   references?: Maybe<Array<UpdateReferenceInput>>;
@@ -1476,14 +1553,14 @@ export type UpdateContextInput = {
   vision?: Maybe<Scalars['Markdown']>;
   /** Update the Visual assets for the new Context. */
   visual?: Maybe<UpdateVisualInput>;
-  who?: Maybe<Scalars['String']>;
+  who?: Maybe<Scalars['Markdown']>;
 };
 
 export type UpdateEcoverseInput = {
   /** The ID or NameID of the Ecoverse. */
   ID: Scalars['UUID_NAMEID'];
   /** Update anonymous visibility for the Ecoverse. */
-  authorizationDefinition?: Maybe<UpdateAuthorizationDefinitionInput>;
+  authorizationPolicy?: Maybe<UpdateAuthorizationPolicyInput>;
   /** Update the contained Context entity. */
   context?: Maybe<UpdateContextInput>;
   /** The display name for this entity. */
@@ -1618,7 +1695,7 @@ export type UserAuthorizationPrivilegesInput = {
 };
 
 export type UserAuthorizationResetInput = {
-  /** The identifier of the User whose AuthorizationDefinition should be reset. */
+  /** The identifier of the User whose Authorization Policy should be reset. */
   userID: Scalars['UUID_NAMEID_EMAIL'];
 };
 

--- a/src/validate-connection.ts
+++ b/src/validate-connection.ts
@@ -7,7 +7,7 @@ const main = async () => {
 
   const ctClient = new AlkemioClient({
     graphqlEndpoint:
-      process.env.GRAPHQL_ENDPOINT ?? 'http://localhost:4455/graphql',
+      process.env.GRAPHQL_ENDPOINT ?? 'http://localhost:3000/graphql',
   });
   console.log(await ctClient.isAuthenticationEnabled());
   ctClient.config.authInfo = await getAuthInfo();
@@ -29,7 +29,7 @@ async function getAuthInfo(): Promise<AuthInfo | undefined> {
       password: process.env.AUTH_ADMIN_PASSWORD ?? '!Rn5Ez5FuuyUNc!',
     },
     apiEndpointFactory: () => {
-      return 'http://localhost:4433/';
+      return 'http://localhost:3000/ory/kratos/public/';
     },
   };
 }

--- a/src/validate-connection.ts
+++ b/src/validate-connection.ts
@@ -29,7 +29,7 @@ async function getAuthInfo(): Promise<AuthInfo | undefined> {
       password: process.env.AUTH_ADMIN_PASSWORD ?? '!Rn5Ez5FuuyUNc!',
     },
     apiEndpointFactory: () => {
-      return 'http://localhost:3000/ory/kratos/public/';
+      return 'http://localhost:3000/identity/ory/kratos/public/';
     },
   };
 }


### PR DESCRIPTION
Updated:
- Kratos base URL with the latest config (http://localhost:3000/identity/ory/kratos/public)
- Gql endpoints to have base url http://localhost:3000/graphql
- Latest gql schema (server 0.12.1)
