### PR TITLE
Kratos API token retrievable cross-domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-lib",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-lib",
-      "version": "0.9.9",
+      "version": "0.10.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/client-lib",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/client-lib",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "EUPL-1.2",
       "dependencies": {
         "axios": "^0.21.1",
@@ -16,6 +16,7 @@
         "graphql-tag": "^2.11.0",
         "jsonpath": "^1.1.1",
         "semver": "^7.3.4",
+        "url-join": "^4.0.1",
         "winston": "^3.3.3"
       },
       "devDependencies": {
@@ -29,6 +30,7 @@
         "@types/node": "^14.14.10",
         "@types/semver": "^7.3.4",
         "@types/supertest": "^2.0.8",
+        "@types/url-join": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^4.9.0",
         "@typescript-eslint/parser": "^4.9.0",
         "eslint": "^7.14.0",
@@ -2980,6 +2982,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
+      "dev": true
     },
     "node_modules/@types/websocket": {
       "version": "1.0.2",
@@ -8466,6 +8474,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
@@ -11431,6 +11444,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==",
+      "dev": true
     },
     "@types/websocket": {
       "version": "1.0.2",
@@ -15733,6 +15752,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-lib",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Library for interacting with a Alkemio server instance",
   "author": "Cherrytwist Foundation",
   "private": false,
@@ -37,6 +37,7 @@
     "@types/node": "^14.14.10",
     "@types/semver": "^7.3.4",
     "@types/supertest": "^2.0.8",
+    "@types/url-join": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "eslint": "^7.14.0",
@@ -56,6 +57,7 @@
     "graphql-tag": "^2.11.0",
     "jsonpath": "^1.1.1",
     "semver": "^7.3.4",
+    "url-join": "^4.0.1",
     "winston": "^3.3.3"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/client-lib",
-  "version": "0.9.10",
+  "version": "0.10.0",
   "description": "Library for interacting with a Alkemio server instance",
   "author": "Cherrytwist Foundation",
   "private": false,

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,6 +1,5 @@
-export type ApiEndpointFactory = () => string;
 export type UserCredentials = { email: string; password: string };
 export type AuthInfo = {
   credentials: UserCredentials;
-  apiEndpointFactory: ApiEndpointFactory;
+  kratosPublicApiEndpoint: string;
 };

--- a/src/util/http.client.ts
+++ b/src/util/http.client.ts
@@ -1,16 +1,18 @@
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
-import { ApiEndpointFactory } from 'src';
 
 export abstract class HttpClient {
   protected readonly instance: AxiosInstance;
+  protected readonly apiBaseURL: string;
+
   protected readonly config = {
     headers: {
       Accept: 'application/json',
     },
   };
 
-  public constructor(apiEndpoint: ApiEndpointFactory) {
-    const baseURL = apiEndpoint();
+  public constructor(apiEndpoint: string) {
+    this.apiBaseURL = apiEndpoint;
+    const baseURL = apiEndpoint;
     this.instance = axios.create({
       baseURL,
     });

--- a/src/util/kratos.public.api.client.ts
+++ b/src/util/kratos.public.api.client.ts
@@ -1,4 +1,4 @@
-import { ApiEndpointFactory, UserCredentials } from 'src';
+import { UserCredentials } from 'src';
 import { HttpClient } from './http.client';
 
 /**
@@ -17,23 +17,21 @@ import { HttpClient } from './http.client';
  * }
  *
  * const main = async () => {
- * const apiEndpointConfig = () =>
- *   process.env.AUTH_ORY_KRATOS_PUBLIC_BASE_URL ?? 'http://localhost:4433/';
  *
  * const token = await getApiToken({
  *   credentials: {
  *     email: process.env.AUTH_ADMIN_EMAIL ?? 'admin@alkem.io',
  *     password: process.env.AUTH_ADMIN_PASSWORD ?? '!Rn5Ez5FuuyUNc!',
  *   },
- *   apiEndpointFactory: apiEndpointConfig,
+ *   kratosPublicApiEndpoint: process.env.AUTH_ORY_KRATOS_PUBLIC_BASE_URL ?? 'http://localhost:4433/',
  * });
  *
  * console.log(token);
  * };
  */
 export class KratosPublicApiClient extends HttpClient {
-  public constructor(apiEndpoint: ApiEndpointFactory) {
-    super(() => apiEndpoint());
+  public constructor(apiEndpoint: string) {
+    super(apiEndpoint);
   }
 
   private async getActionUrl(): Promise<string> {
@@ -41,7 +39,7 @@ export class KratosPublicApiClient extends HttpClient {
       '/self-service/login/api',
       this.config
     );
-    return kratosData.ui?.action;
+    return await this.buildActionURI(kratosData.ui?.action);
   }
 
   /**
@@ -69,5 +67,20 @@ export class KratosPublicApiClient extends HttpClient {
       this.config
     );
     return kratosData.session_token;
+  }
+
+  // Without this, we always get the action URI from the Kratos config (kratos.yml).
+  // Essentially without this an API token can not be received cross-domain, if the application
+  // using client lib can't resolve the endpoints in kratos.yml.
+
+  private async buildActionURI(kratosActionURL: string): Promise<string> {
+    const regex = '(flow=[a-zA-Z0-9-]*)';
+    const found = kratosActionURL.match(regex);
+    if (!found)
+      throw new Error('Could not get Kratos Action URI for API flow!');
+
+    const actionURI = `${this.apiBaseURL}self-service/login?${found[0]}`;
+    console.log(`Action URI: ${actionURI}`);
+    return actionURI;
   }
 }

--- a/src/util/kratos.public.api.client.ts
+++ b/src/util/kratos.public.api.client.ts
@@ -79,7 +79,14 @@ export class KratosPublicApiClient extends HttpClient {
     if (!found)
       throw new Error('Could not get Kratos Action URI for API flow!');
 
-    const actionURI = `${this.apiBaseURL}self-service/login?${found[0]}`;
+    // const actionURI = `${this.apiBaseURL}self-service/login?${found[0]}`;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const urljoin = require('url-join');
+
+    const actionURI = urljoin(
+      this.apiBaseURL,
+      `self-service/login?${found[0]}`
+    );
     console.log(`Action URI: ${actionURI}`);
     return actionURI;
   }

--- a/src/validate-connection.ts
+++ b/src/validate-connection.ts
@@ -1,6 +1,6 @@
-import { AuthInfo } from 'src';
 import { AlkemioClient } from './AlkemioClient';
 import * as dotenv from 'dotenv';
+import { AuthInfo } from 'src';
 
 const main = async () => {
   dotenv.config();
@@ -9,7 +9,14 @@ const main = async () => {
     graphqlEndpoint:
       process.env.GRAPHQL_ENDPOINT ?? 'http://localhost:3000/graphql',
   });
-  ctClient.config.authInfo = await getAuthInfo();
+  ctClient.config.authInfo = {
+    credentials: {
+      email: process.env.AUTH_ADMIN_EMAIL ?? 'admin@alkem.io',
+      password: process.env.AUTH_ADMIN_PASSWORD ?? '!Rn5Ez5FuuyUNc!',
+    },
+    kratosPublicApiEndpoint:
+      'http://localhost:3000/identity/ory/kratos/public/',
+  } as AuthInfo;
 
   await ctClient.enableAuthentication();
 
@@ -20,18 +27,6 @@ const main = async () => {
   const hubExists = await ctClient.hubExists(hubID);
   console.log(`Hub '${hubID}' exists: ${hubExists}`);
 };
-
-async function getAuthInfo(): Promise<AuthInfo | undefined> {
-  return {
-    credentials: {
-      email: process.env.AUTH_ADMIN_EMAIL ?? 'admin@alkem.io',
-      password: process.env.AUTH_ADMIN_PASSWORD ?? '!Rn5Ez5FuuyUNc!',
-    },
-    apiEndpointFactory: () => {
-      return 'http://localhost:3000/identity/ory/kratos/public/';
-    },
-  };
-}
 
 try {
   main();


### PR DESCRIPTION
Multiple issues fixed / to focus on during the review:
- Kratos API Endpoint Factory is replaced with a config. Easier to debug + trace issues that way.
- Changed the Action URI logic for API logins. The orthodox Kratos flow is not cross-domain, and even in dev scenarios it builds the action URI in one domain, the one defined in kratos.yml, completely ignoring the baseURL configuration
- Changed the Kratos API Base URL logic - it was making a call out to the server api to retrieve the configuration, even when one was provided
- Added additional logging. To be discussed how / whether to keep it.